### PR TITLE
FIX: use `to_datetime` method to parse "last reminded at" value.

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -18,9 +18,9 @@ module ::Kolide
 
       render body: nil, status: 200
     end
-  
+
     private
-  
+
     def is_valid_signature?(body)
       signature = request.headers['HTTP_AUTHORIZATION']
       signature == OpenSSL::HMAC.hexdigest('sha256', SiteSetting.kolide_webhook_secret, body)

--- a/lib/alert.rb
+++ b/lib/alert.rb
@@ -15,7 +15,7 @@ module ::Kolide
 
       @issues = Issue.joins(:device).where("kolide_devices.user_id = ?", user.id)
       @post = Post.find_by(id: post_id_field.value) if post_id_field.present?
-      
+
       if post_id_field.blank? || @post.blank?
         @post = create_post!
         post_id_field.value = @post.id
@@ -49,7 +49,7 @@ module ::Kolide
     end
 
     def last_reminded_at
-      DateTime.parse(last_reminded_at_field.value.presence || "")
+      (last_reminded_at_field.value.presence || "").to_datetime
     end
 
     private


### PR DESCRIPTION
The method "DateTime.parse" won't work for empty strings.
And fixed the minor linting issues.