### PR TITLE
FIX: take 2 on stopping notification flood.

### DIFF
--- a/lib/alert.rb
+++ b/lib/alert.rb
@@ -41,7 +41,7 @@ module ::Kolide
         }
       )
 
-      last_reminded_at = remind_at
+      set_last_reminded_at(remind_at)
     end
 
     def topic_title
@@ -76,7 +76,7 @@ module ::Kolide
         validate: false
       )
 
-      self.last_reminded_at = post.created_at
+      set_last_reminded_at(post.created_at)
       post
     end
 
@@ -115,7 +115,7 @@ module ::Kolide
       issues.where(resolved: false, ignored: false)
     end
 
-    def last_reminded_at=(value)
+    def set_last_reminded_at(value)
       last_reminded_at_field.value = value
       last_reminded_at_field.save!
     end

--- a/spec/lib/alert_spec.rb
+++ b/spec/lib/alert_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe ::Kolide::Alert do
 
   let(:user) { Fabricate(:user) }
 
-  it "creates a PM with issues and sends a reminder" do
+  it "creates a PM with issues and a bookmark" do
     device = ::Kolide::Device.create!(
       uid: "12345",
       user_id: user.id,
@@ -28,8 +28,7 @@ RSpec.describe ::Kolide::Alert do
       resolved_at: nil
     )
 
-    now = Time.zone.now
-    freeze_time now
+    freeze_time
 
     alert = nil
     expect { alert = ::Kolide::Alert.new(user) }.to change { Topic.private_messages_for_user(user).count }.by(1)
@@ -37,15 +36,15 @@ RSpec.describe ::Kolide::Alert do
     pm = Topic.private_messages_for_user(user).last
     expect(pm.title).to eq(alert.topic_title)
 
-    now += 1.hour
-    freeze_time now
-
+    freeze_time 1.hour.from_now
     expect { alert.remind! }.to change { user.bookmarks.count }.by(0)
 
-    now += 1.day
-    freeze_time now
-
+    freeze_time 1.day.from_now
     expect { alert.remind! }.to change { user.bookmarks.count }.by(1)
+
+    user.bookmarks.last.destroy!
+    freeze_time 1.hour.from_now
+    expect { alert.remind! }.to change { user.bookmarks.count }.by(0)
   end
 
 end


### PR DESCRIPTION
Without `self.` prefix Ruby treating `last_reminded_at` as a local variable while calling it in code `last_reminded_at = remind_at`. So I'm using normal method format here to reduce confusion.