### PR TITLE
FIX: use `logger.warn` instead of `Discourse.warn` method.

### DIFF
--- a/plugin.rb
+++ b/plugin.rb
@@ -69,7 +69,7 @@ after_initialize do
         user = User.find_by_email(email)
 
         if user.blank?
-          Discourse.warn("Unable find the Discourse user for email address '#{email}'")
+          Rails.logger.warn("Unable find the Discourse user for email address '#{email}'")
           return
         end
 


### PR DESCRIPTION
We should use logger's warn method here since `Discourse.warn` demands one more parameter.