### PR TITLE
FIX: add default text for post body if issues not found.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -22,6 +22,7 @@ en:
         | Device | Primary Username | Hardware | Issue | Resolved At |
         | - | - | - | - | - |
         %{rows}
+      no_issues: "Issues not found."
     group_alert:
       title: "%{count} Kolide devices has problems"
       body: |
@@ -30,5 +31,6 @@ en:
         | ID | Device | Primary Username | Hardware | Last IP |
         | - | - | - | - | - |
         %{rows}
+      no_issues: "Issues not found."
     error:
       invalid_response: "Invalid response received from Kolide API"

--- a/lib/group_alert.rb
+++ b/lib/group_alert.rb
@@ -81,7 +81,7 @@ module ::Kolide
     end
 
     def post_body
-      return unless devices.exists?
+      return I18n.t("kolide.group_alert.no_issues") unless devices.exists?
 
       rows = []
       devices.each do |device|

--- a/lib/user_alert.rb
+++ b/lib/user_alert.rb
@@ -94,7 +94,7 @@ module ::Kolide
     end
 
     def post_body
-      return unless issues.exists?
+      return I18n.t("kolide.alert.no_issues") unless issues.exists?
 
       open_issues = build_list_for(:open)
       resolved_issues = build_list_for(:resolved)

--- a/spec/lib/user_alert_spec.rb
+++ b/spec/lib/user_alert_spec.rb
@@ -45,6 +45,9 @@ RSpec.describe ::Kolide::UserAlert do
     user.bookmarks.last.destroy!
     freeze_time 1.hour.from_now
     expect { alert.remind! }.to change { user.bookmarks.count }.by(0)
+
+    ::Kolide::Issue.update_all(resolved: true)
+    expect(pm.first_post.raw).to eq(I18n.t("kolide.alert.no_issues"))
   end
 
 end


### PR DESCRIPTION
We can't update an existing post with empty body content. Instead, we're adding the default text now.