### PR TITLE
UX: remove link to the Kolide for device issues.

### DIFF
--- a/lib/user_alert.rb
+++ b/lib/user_alert.rb
@@ -120,8 +120,7 @@ module ::Kolide
         device = issue.device
         at = (key == :open) ? issue.reported_at : issue.resolved_at
         at = "[#{at.strftime("date=%Y-%m-%d time=%H:%M:%S")} timezone='UTC' format='L LT']" if at.present?
-        url = "https://k2.kolide.com/my/inventory/devices/#{device.uid}/issues/open"
-        rows << "| #{device.name} | #{device.primary_user_name} | #{device.hardware_model} | [#{issue.title}](#{url}) | #{at} |"
+        rows << "| #{device.name} | #{device.primary_user_name} | #{device.hardware_model} | #{issue.title} | #{at} |"
       end
 
       I18n.t("kolide.alert.#{key}_issues", rows: rows.join("\n"))


### PR DESCRIPTION
Currently, end users have no access to the issues in Kolide UI.