### PR TITLE
FIX: don't remind users when no issues found.

### DIFF
--- a/lib/user_alert.rb
+++ b/lib/user_alert.rb
@@ -26,7 +26,8 @@ module ::Kolide
       return if post.blank?
 
       update_post_body
-      return if open_issues.count > 0 && last_reminded_at.present? && last_reminded_at > REMINDER_INTERVAL.ago
+      return if open_issues.count == 0
+      return if last_reminded_at.present? && last_reminded_at > REMINDER_INTERVAL.ago
 
       bookmark_manager = BookmarkManager.new(user)
       bookmark_id = Bookmark.where(user_id: user.id, post_id: post.id, name: REMINDER_NAME).pluck(:id).first


### PR DESCRIPTION
Similar to the issue https://github.com/discourse/discourse-kolide/commit/ca1824d53156f8d61af23e16afafa7ce6882fc20