### PR TITLE
FEATURE: sync Kolide checks & delay user reminders based on checks.

### DIFF
--- a/app/models/check.rb
+++ b/app/models/check.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module ::Kolide
+
+  class Check < ::ActiveRecord::Base
+    self.table_name = "kolide_checks"
+
+    has_many :issues
+
+    def self.find_or_create_by_json(data)
+      check = where(uid: data["id"]).first_or_initialize(
+        name: data["name"],
+        display_name: data["display_name"],
+        description: data["description"]
+      )
+
+      check.failing_device_count = data["failing_device_count"]
+      check.save! if check.changed?
+
+      check
+    end
+
+    def self.sync_all!
+      response = Kolide.api.get("checks")
+      return if response[:error].present?
+
+      response["data"].each do |data|
+        find_or_create_by_json(data)
+      end
+    end
+  end
+end

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -6,6 +6,7 @@ module ::Kolide
     self.table_name = "kolide_devices"
 
     has_many :issues
+    belongs_to :user
 
     def self.find_or_create_by_json(data)
       device = where(uid: data["id"]).first_or_initialize(

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -6,6 +6,7 @@ module ::Kolide
     self.table_name = "kolide_issues"
 
     belongs_to :device
+    belongs_to :check
 
     def self.find_or_create_by_json(data)
       issue = where(uid: data["id"]).first_or_initialize(
@@ -17,6 +18,12 @@ module ::Kolide
         device = Device.find_or_create_by_json(data["device"])
         return if device.blank?
         issue.device_id = device.id
+      end
+
+      if issue.check_id.blank?
+        check = Check.find_by(uid: data["check_id"])
+        return if check.blank?
+        issue.check_id = check.id
       end
 
       issue.ignored = data["ignored"]

--- a/db/migrate/20211220131537_create_kolide_checks_table.rb
+++ b/db/migrate/20211220131537_create_kolide_checks_table.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateKolideChecksTable < ActiveRecord::Migration[6.0]
+  def change
+    create_table :kolide_checks do |t|
+      t.integer :uid, null: false, index: true, unique: true
+      t.string :name
+      t.string :display_name
+      t.string :description
+      t.integer :delay, default: 0
+      t.integer :failing_device_count, default: 0
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20211220142530_add_check_id_to_issues.rb
+++ b/db/migrate/20211220142530_add_check_id_to_issues.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class AddCheckIdToIssues < ActiveRecord::Migration[6.1]
+  def up
+    add_column :kolide_issues, :check_id, :integer
+  end
+
+  def down
+    remove_column :kolide_issues, :check_id
+  end
+end

--- a/lib/user_alert.rb
+++ b/lib/user_alert.rb
@@ -26,8 +26,8 @@ module ::Kolide
       return if post.blank?
 
       update_post_body
-      return if open_issues.count == 0
       return if last_reminded_at.present? && last_reminded_at > REMINDER_INTERVAL.ago
+      return unless open_issues.joins(:check).where("(#{Time.now.to_i} - EXTRACT(EPOCH FROM kolide_issues.reported_at))/3600 > kolide_checks.delay").exists?
 
       bookmark_manager = BookmarkManager.new(user)
       bookmark_id = Bookmark.where(user_id: user.id, post_id: post.id, name: REMINDER_NAME).pluck(:id).first

--- a/plugin.rb
+++ b/plugin.rb
@@ -27,6 +27,7 @@ after_initialize do
 
     def self.sync!
       Device.sync_all!
+      Check.sync_all!
       device_ids = Issue.sync_open!
       user_ids = ::Kolide::Device.where(id: device_ids).where.not(user_id: nil).pluck(:user_id).uniq
 
@@ -41,6 +42,7 @@ after_initialize do
   [
     '../app/controllers/webhooks_controller.rb',
     '../app/jobs/scheduled/sync_kolide.rb',
+    '../app/models/check.rb',
     '../app/models/device.rb',
     '../app/models/issue.rb',
     '../lib/api.rb',

--- a/spec/fabricators/kolide_fabricator.rb
+++ b/spec/fabricators/kolide_fabricator.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+Fabricator(:kolide_device, from: "::Kolide::Device") do
+  user
+  uid { sequence(:uid) }
+  name "My Mac"
+  primary_user_name "deviceadmin"
+  hardware_model "Macbook"
+end
+
+Fabricator(:kolide_check, from: "::Kolide::Check") do
+  uid { sequence(:uid) }
+  name "Ensure Supported OS Version"
+  display_name "Windows Update - Ensure Supported OS Version"
+  description "Obsolete Windows versions no longer receive important security updates and patches, and could leave you vulnerable to exploits."
+  failing_device_count 1
+  delay 0
+end
+
+Fabricator(:kolide_issue, from: "::Kolide::Issue") do
+  device
+  check
+  uid { sequence(:uid) }
+  title "Screen Lock Disabled"
+  data '{ "user": "deviceuser" }'
+  reported_at 1.days.ago
+  resolved_at nil
+end


### PR DESCRIPTION
ex: If we set `check.delay = 24` then users will get reminder for that check related issues after 1 day only.