### PR TITLE
FEATURE: save user IPs in custom field & match against device IPs

### DIFF
--- a/db/post_migrate/20220104150337_populate_ip_addresses_field.rb
+++ b/db/post_migrate/20220104150337_populate_ip_addresses_field.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class PopulateIpAddressesField < ActiveRecord::Migration[6.1]
+  def up
+    execute <<~SQL
+      INSERT INTO user_custom_fields (user_id, name, value, created_at, updated_at)
+      SELECT id, 'kolide_ip_addresses', host(ip_address), created_at, updated_at
+      FROM users
+      WHERE ip_address IS NOT NULL
+    SQL
+  end
+
+  def down
+  end
+end

--- a/lib/group_alert.rb
+++ b/lib/group_alert.rb
@@ -96,7 +96,9 @@ module ::Kolide
       rows = []
       devices.each do |device|
         url = "https://k2.kolide.com/my/inventory/devices/#{device.uid}"
-        rows << "| [#{device.uid}](#{url}) | #{device.name} | #{device.primary_user_name} | #{device.hardware_model} | #{device.ip_address} |"
+        user = UserCustomField.find_by(name: User::IP_ADDRESSES_FIELD, value: device.ip_address.to_s)&.user
+        user_info = user.present? ? " (#{user.username})" : ""
+        rows << "| [#{device.uid}](#{url}) | #{device.name} | #{device.primary_user_name} | #{device.hardware_model} | #{device.ip_address}#{user_info} |"
       end
 
       I18n.t("kolide.group_alert.body", rows: rows.join("\n"))

--- a/plugin.rb
+++ b/plugin.rb
@@ -70,6 +70,7 @@ after_initialize do
       def update_kolide_ip_addresses
         current_ip = ip_address&.to_s
         return if current_ip.blank?
+        return unless saved_change_to_ip_address?
 
         ip_addresses = custom_fields[IP_ADDRESSES_FIELD] || []
 

--- a/plugin.rb
+++ b/plugin.rb
@@ -58,9 +58,29 @@ after_initialize do
     mount ::Kolide::Engine, at: '/kolide'
   end
 
+  User.register_custom_field_type "kolide_ip_addresses", [:string]
+
   reloadable_patch do |plugin|
     require_dependency 'user'
     class ::User
+      after_commit :update_kolide_ip_addresses, on: [:create, :update]
+
+      IP_ADDRESSES_FIELD = 'kolide_ip_addresses'
+
+      def update_kolide_ip_addresses
+        current_ip = ip_address&.to_s
+        return if current_ip.blank?
+
+        ip_addresses = custom_fields[IP_ADDRESSES_FIELD] || []
+
+        # moving current IP to the last position
+        ip_addresses -= [current_ip]
+        ip_addresses += [current_ip]
+
+        custom_fields[IP_ADDRESSES_FIELD] = ip_addresses.last(10)
+        save_custom_fields
+      end
+
       def self.find_by_kolide_json(data)
         return if data.blank?
 

--- a/spec/fabricators/kolide_fabricator.rb
+++ b/spec/fabricators/kolide_fabricator.rb
@@ -6,6 +6,7 @@ Fabricator(:kolide_device, from: "::Kolide::Device") do
   name "My Mac"
   primary_user_name "deviceadmin"
   hardware_model "Macbook"
+  ip_address "127.0.0.1"
 end
 
 Fabricator(:kolide_check, from: "::Kolide::Check") do

--- a/spec/lib/group_alert_spec.rb
+++ b/spec/lib/group_alert_spec.rb
@@ -5,6 +5,7 @@ require 'rails_helper'
 RSpec.describe ::Kolide::GroupAlert do
 
   let(:group) { Fabricate(:group) }
+  let(:device) { Fabricate(:kolide_device, user: nil) }
 
   before do
     SiteSetting.kolide_enabled = true
@@ -13,14 +14,7 @@ RSpec.describe ::Kolide::GroupAlert do
   end
 
   it "creates a group PM if unassigned devices are present" do
-    device = ::Kolide::Device.create!(
-      uid: "12345",
-      name: "My Mac",
-      primary_user_name: "deviceadmin",
-      hardware_model: "Macbook",
-      ip_address: "127.0.0.1"
-    )
-
+    device
     freeze_time
 
     alert = nil
@@ -29,7 +23,20 @@ RSpec.describe ::Kolide::GroupAlert do
 
     pm = group_pms.first
     expect(pm.title).to eq(I18n.t('kolide.group_alert.title', count: 1))
-    expected_row = "| [12345](https://k2.kolide.com/my/inventory/devices/12345) | My Mac | deviceadmin | Macbook | 127.0.0.1 |"
+    expected_row = "| [#{device.uid}](https://k2.kolide.com/my/inventory/devices/#{device.uid}) | #{device.name} | #{device.primary_user_name} | #{device.hardware_model} | #{device.ip_address} |"
+    expect(pm.first_post.raw).to eq(I18n.t('kolide.group_alert.body', rows: expected_row).strip)
+  end
+
+  it "will match the corresponding user by IP address" do
+    user = Fabricate(:user, ip_address: device.ip_address)
+
+    freeze_time
+
+    group_pms = Topic.joins(:topic_allowed_groups).where("topic_allowed_groups.group_id = ?", group.id)
+    described_class.new
+
+    pm = group_pms.first
+    expected_row = "| [#{device.uid}](https://k2.kolide.com/my/inventory/devices/#{device.uid}) | #{device.name} | #{device.primary_user_name} | #{device.hardware_model} | #{user.ip_address} (#{user.username}) |"
     expect(pm.first_post.raw).to eq(I18n.t('kolide.group_alert.body', rows: expected_row).strip)
   end
 

--- a/spec/plugin_spec.rb
+++ b/spec/plugin_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+describe 'plugin' do
+
+  let(:user) { Fabricate(:user) }
+
+  before do
+    SiteSetting.kolide_enabled = true
+    SiteSetting.kolide_api_key = "KOLIDE_API_KEY"
+  end
+
+  it 'saves user ip addresses in custom field' do
+    old_ip_address = user.ip_address.to_s
+    new_ip_address = "127.0.0.10"
+
+    user.ip_address = new_ip_address
+    user.save!
+
+    expect(user.custom_fields[User::IP_ADDRESSES_FIELD]).to contain_exactly(old_ip_address, new_ip_address)
+  end
+end


### PR DESCRIPTION
Now we will save last 10 IP addresses of users in custom field and we will match against the Kolide device IP addresses while creating the Kolide admins group PM alert.