### PR TITLE
FIX: treat webhook event payload data as hash to get user_id

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -44,7 +44,7 @@ module ::Kolide
 
       if event == "devices.reassigned"
         user = User.find_by_kolide_json(data["new_owner"])
-        device.update(user_id: user&.id) if data.user_id != user&.id
+        device.update(user_id: user&.id) if data["user_id"] != user&.id
       end
     end
 

--- a/spec/fixtures/reassigned.json
+++ b/spec/fixtures/reassigned.json
@@ -1,0 +1,16 @@
+{
+  "event": "devices.reassigned",
+  "id": "01FHFHAJ4S2ZJGPRE7EFAQFKRP",
+  "timestamp": "2022-01-06T01:53:59Z",
+  "data": {
+    "device_id": 89701,
+    "device_name": "pc.abc",
+    "previous_owner": null,
+    "new_owner": {
+      "id": 264902,
+      "type": "Person",
+      "name": "John Bob",
+      "email": "john.bob@example.com"
+    }
+  }
+}

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require 'openssl'
+require 'json'
+require_relative '../spec_helper'
+
+RSpec.describe ::Kolide::WebhooksController do
+  include_context "spec helper"
+
+  let(:secret) { SiteSetting.kolide_webhook_secret = "WEBHOOK SECRET" }
+
+  before do
+    SiteSetting.queue_jobs = false
+  end
+
+  def post_request(body)
+    post '/kolide/webhooks', params: body, headers: {
+      'HTTP_AUTHORIZATION': OpenSSL::HMAC.hexdigest("sha256", secret, body)
+    }
+  end
+
+  context "index" do
+    it 'updates the device to corresponding user when reassigned' do
+      body = get_kolide_response('reassigned.json')
+      data = JSON.parse(body)["data"]
+      device_id = data["device_id"]
+      device = Fabricate(:kolide_device, uid: device_id, user_id: nil)
+      user = Fabricate(:user, email: data["new_owner"]["email"])
+
+      post_request(body)
+
+      expect(response.status).to eq(200)
+      expect(Kolide::Device.find_by_uid(device_id).user_id).to eq(user.id)
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,11 @@
 
 RSpec.shared_context "spec helper" do
 
+  before do
+    SiteSetting.kolide_enabled = true
+    SiteSetting.kolide_api_key = "KOLIDE_API_KEY"
+  end
+
   def get_kolide_response(filename)
     FileUtils.mkdir_p("#{Rails.root}/tmp/spec") unless Dir.exists?("#{Rails.root}/tmp/spec")
     FileUtils.cp("#{Rails.root}/plugins/discourse-kolide/spec/fixtures/#{filename}", "#{Rails.root}/tmp/spec/#{filename}")


### PR DESCRIPTION
Previously, it returned the error since we retrieved the `user_id` in the wrong way.