### PR TITLE
FIX: `Content-Type` header is required for PUT methods on Kolide API.

### DIFF
--- a/lib/api.rb
+++ b/lib/api.rb
@@ -10,7 +10,11 @@ module ::Kolide
     def initialize
       @client = Faraday.new(
         url: Api::BASE_URL,
-        headers: { 'Authorization' => "Bearer #{SiteSetting.kolide_api_key}" }
+        headers: {
+          'Authorization' => "Bearer #{SiteSetting.kolide_api_key}",
+          'Accept' => "application/json",
+          'Content-Type' => "application/json"
+        }
       )
     end
 

--- a/spec/requests/devices_controller_spec.rb
+++ b/spec/requests/devices_controller_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe ::Kolide::DevicesController do
       stub_request(:put, "#{::Kolide::Api::BASE_URL}devices/#{device.uid}/owner").with do |req|
         data = JSON.parse(req.body.to_s)
         expect(data["owner_id"]).to eq("98765")
+        expect(req.headers["Content-Type"]).to eq("application/json")
       end.to_return(status: 200, body: "{}", headers: {})
     end
 


### PR DESCRIPTION
Previously, Kolide API returned an error while trying to assign a device owner using the PUT method. We should specify the header value 'Content-Type' => "application/json" to fix it.