### PR TITLE
FEATURE: update user alert PM content after a device is destroyed.

### DIFF
--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -9,6 +9,12 @@ module ::Kolide
     has_many :issues, dependent: :destroy
     belongs_to :user
 
+    after_destroy :update_user_alert_pm
+
+    def update_user_alert_pm
+      UserAlert.new(self.user).remind!
+    end
+
     def self.find_or_create_by_json(data)
       device = where(uid: data["id"]).first_or_initialize(
         hardware_model: data["hardware_model"],

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -23,4 +23,19 @@ describe ::Kolide::Device do
     expect { issue.reload }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
+  describe "#destroy" do
+    it "updates user alert PM" do
+      device = Fabricate(:kolide_device)
+      issue = Fabricate(:kolide_issue, device: device)
+      ::Kolide::UserAlert.new(device.user).remind!
+
+      post = Topic.last.first_post
+      expect(post.raw).to include("Screen Lock Disabled")
+
+      device.destroy
+
+      expect(post.reload.raw).to include(I18n.t("kolide.group_alert.no_issues"))
+    end
+  end
+
 end


### PR DESCRIPTION
Previously, the PM is not updated automatically. So it confuses the end users.