### PR TITLE
FIX: skip PM alert update if user not found.

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -23,6 +23,8 @@ module ::Kolide
         Issue.sync!(data["issue_id"], event)
       elsif ["devices.created", "devices.reassigned"].include?(event)
         Device.sync!(data["device_id"], event, data)
+      elsif ["devices.destroyed"].include?(event)
+        Device.find_by(uid: data["device_id"])&.destroy
       end
 
       render body: nil, status: 200

--- a/app/models/device.rb
+++ b/app/models/device.rb
@@ -12,7 +12,7 @@ module ::Kolide
     after_destroy :update_user_alert_pm
 
     def update_user_alert_pm
-      UserAlert.new(self.user).remind!
+      UserAlert.new(self.user).remind! if self.user.present?
     end
 
     def self.find_or_create_by_json(data)

--- a/spec/fixtures/destroyed.json
+++ b/spec/fixtures/destroyed.json
@@ -1,0 +1,9 @@
+{
+  "event": "devices.destroyed",
+  "id": "017QPB56HR54G4S2A873456",
+  "timestamp": "2021-04-28T04:18:37Z",
+  "data": {
+    "device_id": 10037,
+    "device_name": "MyDevice"
+  }
+}

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -24,17 +24,27 @@ describe ::Kolide::Device do
   end
 
   describe "#destroy" do
-    it "updates user alert PM" do
-      device = Fabricate(:kolide_device)
+    fab!(:device) { Fabricate(:kolide_device) }
+
+    before do
       issue = Fabricate(:kolide_issue, device: device)
       ::Kolide::UserAlert.new(device.user).remind!
+    end
 
+    it "updates user alert PM" do
       post = Topic.last.first_post
       expect(post.raw).to include("Screen Lock Disabled")
 
       device.destroy
 
       expect(post.reload.raw).to include(I18n.t("kolide.group_alert.no_issues"))
+    end
+
+    it "skips PM update if user not found" do
+      ::Kolide::UserAlert.any_instance.expects(:remind!).never
+
+      device.user.destroy
+      device.reload.destroy
     end
   end
 

--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -34,6 +34,20 @@ RSpec.describe ::Kolide::WebhooksController do
       expect(Kolide::Device.find_by_uid(device_id).user_id).to eq(user.id)
     end
 
+    it 'removes the device and updates the user PM' do
+      body = get_kolide_response('destroyed.json')
+      data = JSON.parse(body)["data"]
+      device_id = data["device_id"]
+      user = Fabricate(:user)
+      device = Fabricate(:kolide_device, uid: device_id, user: user)
+      ::Kolide::UserAlert.any_instance.expects(:remind!).once
+
+      post_request(body)
+
+      expect(response.status).to eq(200)
+      expect(Kolide::Device.find_by_uid(device_id)).to be_nil
+    end
+
     it 'updates the user alert PM post when issue is resolved' do
       body = get_kolide_response('resolved.json')
       data = JSON.parse(body)["data"]


### PR DESCRIPTION
And also sync destroyed devices from Kolide via webhook.