### PR TITLE
FEATURE: add username in user alert topic's title.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -9,7 +9,7 @@ en:
     kolide_helpers_group_name: 'The group name of Kolide helpers who will help users to resolve their open issues'
   kolide:
     alert:
-      title: "Found %{count} problems in your devices"
+      title: "Found %{count} problems in your devices - @%{username}"
       body: |
         %{open_issues}
 

--- a/lib/user_alert.rb
+++ b/lib/user_alert.rb
@@ -48,7 +48,7 @@ module ::Kolide
     end
 
     def topic_title
-      I18n.t('kolide.alert.title', count: open_issues.count)
+      I18n.t('kolide.alert.title', count: open_issues.count, username: user.username)
     end
 
     def last_reminded_at

--- a/spec/lib/user_alert_spec.rb
+++ b/spec/lib/user_alert_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe ::Kolide::UserAlert do
 
     pm = Topic.private_messages_for_user(user).last
     post = pm.first_post
-    expect(pm.title).to eq(alert.topic_title)
+    expect(pm.title).to eq(I18n.t('kolide.alert.title', count: 1, username: user.username))
     expect(post.raw).to include("[^#{issue.id}]: user: deviceuser")
 
     freeze_time 1.hour.from_now


### PR DESCRIPTION
Without username unable to identify the PM recipients in Kolide helpers group inbox.