### PR TITLE
UX: remove alert notification if issues are resolved in all devices.

### DIFF
--- a/lib/group_alert.rb
+++ b/lib/group_alert.rb
@@ -24,7 +24,15 @@ module ::Kolide
 
     def remind!
       update_post_body
-      return if devices.count == 0
+
+      if devices.count == 0
+        Notification
+          .where(notification_type: Notification.types[:bookmark_reminder])
+          .where("data::json ->> 'bookmark_name' = '#{REMINDER_NAME}'")
+          .destroy_all
+        return
+      end
+
       return if last_reminded_at.present? && last_reminded_at > REMINDER_INTERVAL.ago
 
       remind_at = 5.minutes.from_now

--- a/spec/lib/group_alert_spec.rb
+++ b/spec/lib/group_alert_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe ::Kolide::GroupAlert do
 
-  let(:group) { Fabricate(:group) }
-  let(:device) { Fabricate(:kolide_device, user: nil) }
+  fab!(:group) { Fabricate(:group) }
+  fab!(:device) { Fabricate(:kolide_device, user: nil) }
 
   before do
     SiteSetting.kolide_enabled = true
@@ -14,7 +14,6 @@ RSpec.describe ::Kolide::GroupAlert do
   end
 
   it "creates a group PM if unassigned devices are present" do
-    device
     freeze_time
 
     alert = nil
@@ -25,6 +24,27 @@ RSpec.describe ::Kolide::GroupAlert do
     expect(pm.title).to eq(I18n.t('kolide.group_alert.title', count: 1))
     expected_row = "| [#{device.uid}](https://k2.kolide.com/x/inventory/devices/#{device.uid}) | #{device.name} | #{device.hardware_model} | #{device.ip_address} |"
     expect(pm.first_post.raw).to eq(I18n.t('kolide.group_alert.body', rows: expected_row).strip)
+  end
+
+  it "removes the notification if issues are resolved in all the devices" do
+    user = Fabricate(:user)
+    group.add(user)
+    other_notification = Fabricate(:notification, user: user)
+
+    freeze_time
+    group_alert = described_class.new
+    group_alert.remind!
+
+    freeze_time (1.day.from_now)
+    group_alert.remind!
+    freeze_time (10.minutes.from_now)
+    expect { Jobs::BookmarkReminderNotifications.new.execute({}) }.to change { user.notifications.count }.by(1)
+
+    device.user = Fabricate(:user)
+    device.save!
+
+    expect { group_alert.remind! }.to change { user.notifications.count }.by(-1)
+    expect(other_notification.reload).to be_present
   end
 
   it "will match the corresponding user by IP address" do


### PR DESCRIPTION
Previously, the notification which sent to the Kolide admin group users for the missing device assignment reason keep alerting them even after the device is assigned to someone.