### PR TITLE
FIX: use "`cursor`" pagination param to fetch all the records from API.

### DIFF
--- a/app/models/kolide/check.rb
+++ b/app/models/kolide/check.rb
@@ -22,10 +22,10 @@ module Kolide
     end
 
     def self.sync_all!
-      response = Kolide.api.get("checks")
+      response = Kolide.api.get_all("checks")
       return if response[:error].present?
 
-      response["data"].each { |data| find_or_create_by_json(data) }
+      response[:data].each { |data| find_or_create_by_json(data) }
     end
   end
 end

--- a/app/models/kolide/device.rb
+++ b/app/models/kolide/device.rb
@@ -26,11 +26,11 @@ module Kolide
     end
 
     def self.sync_all!
-      response = Kolide.api.get("devices")
+      response = Kolide.api.get_all("devices")
       return if response[:error].present?
 
       device_ids = []
-      response["data"].each do |data|
+      response[:data].each do |data|
         device_ids << data["id"]
         find_or_create_by_json(data)
       end

--- a/app/models/kolide/issue.rb
+++ b/app/models/kolide/issue.rb
@@ -46,12 +46,12 @@ module Kolide
     end
 
     def self.sync_open!
-      response = Kolide.api.get("issues/open")
+      response = Kolide.api.get_all("issues/open")
       return if response[:error].present?
 
       open_issue_ids = []
       device_ids = []
-      response["data"].each do |data|
+      response[:data].each do |data|
         issue = find_or_create_by_json(data)
         next if issue.blank?
 

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -63,6 +63,8 @@ module ::Kolide
           params[:cursor] = response["pagination"]["next_cursor"]
           break if params[:cursor].blank?
         end
+
+        result
       end
     end
   end

--- a/lib/api.rb
+++ b/lib/api.rb
@@ -43,13 +43,26 @@ module ::Kolide
     %i[get put post].each do |request_method|
       define_method(request_method) do |uri, params = {}|
         if request_method == :get
-          params[:per_page] ||= 500
+          params[:per_page] ||= 100
         else
           params = params.to_json
         end
 
         response = client.public_send(request_method, uri, params)
         parse(response)
+      end
+
+      def get_all(uri, params = {})
+        result = { data: [] }
+
+        loop do
+          response = get(uri, params)
+          return response if response[:error].present?
+
+          result[:data] += response["data"]
+          params[:cursor] = response["pagination"]["next_cursor"]
+          break if params[:cursor].blank?
+        end
       end
     end
   end

--- a/spec/fixtures/checks.json
+++ b/spec/fixtures/checks.json
@@ -440,7 +440,7 @@
     }
   ],
   "pagination": {
-    "next": "https://k2.kolide.com/api/v0/checks?cursor=",
+    "next": "",
     "next_cursor": "",
     "current_cursor": "",
     "count": 25

--- a/spec/fixtures/checks.json
+++ b/spec/fixtures/checks.json
@@ -440,8 +440,8 @@
     }
   ],
   "pagination": {
-    "next": "https://k2.kolide.com/api/v0/checks?cursor=MjcsMjc=",
-    "next_cursor": "MjcsMjc=",
+    "next": "https://k2.kolide.com/api/v0/checks?cursor=",
+    "next_cursor": "",
     "current_cursor": "",
     "count": 25
   }

--- a/spec/fixtures/devices.json
+++ b/spec/fixtures/devices.json
@@ -88,5 +88,11 @@
       "location": null,
       "product_image_url": "https://assets1.kolide.com/assets/inventory/devices/VMware Virtual Platform-9caedeb5450d0aaff20171bb23c419901aae2be6.png"
     }
-  ]
+  ],
+  "pagination": {
+    "next": "",
+    "next_cursor": "",
+    "current_cursor": "",
+    "count": 25
+  }
 }

--- a/spec/fixtures/issues.json
+++ b/spec/fixtures/issues.json
@@ -145,8 +145,8 @@
     }
   ],
   "pagination": {
-    "next": "https://k2.kolide.com/api/v0/issues?cursor=",
-    "next_cursor": "",
+    "next": "https://k2.kolide.com/api/v0/issues/open?cursor=MjcsMjcp",
+    "next_cursor": "MjcsMjcp",
     "current_cursor": "",
     "count": 25
   }

--- a/spec/fixtures/issues.json
+++ b/spec/fixtures/issues.json
@@ -143,5 +143,11 @@
         "product_image_url": "https://assets1.kolide.com/assets/inventory/devices/MacBook Pro (16-inch, 2021)-6a6b3020116ffc65ad7a6b1b462d0cd5ac861f69.png"
       }
     }
-  ]
+  ],
+  "pagination": {
+    "next": "https://k2.kolide.com/api/v0/issues?cursor=",
+    "next_cursor": "",
+    "current_cursor": "",
+    "count": 25
+  }
 }

--- a/spec/fixtures/issues_2.json
+++ b/spec/fixtures/issues_2.json
@@ -1,0 +1,85 @@
+{
+  "data": [
+    {
+      "id": 1884435,
+      "check_id": 3,
+      "issue_key": "path",
+      "issue_value": "/Users/john/.ssh/id_rsa.do",
+      "title": "Unencrypted SSH Key Detected",
+      "value": {
+        "gid": 10,
+        "md5": "6c101ad3929600ca3b26168e527a8",
+        "uid": 107,
+        "bits": 2048,
+        "path": "/Users/john/.ssh/id_rsa.do",
+        "sha256": "84f88e8c66e6ab6269f472233ea3308163b52fcf386922d5dc4d0685835",
+        "key_type": "ssh-rsa",
+        "username": "john",
+        "encrypted": false,
+        "created_at": "2023-03-01T07:40:36.451Z",
+        "group_name": "staff",
+        "updated_at": "2023-03-07T07:40:36.451Z",
+        "file_created_at": "2022-06-31T10:06:52.000Z",
+        "fingerprint_md5": null,
+        "fingerprint_sha256": null
+      },
+      "ignored": false,
+      "escalation_status": "Not Escalated",
+      "resolved_at": null,
+      "timestamp": "2023-03-07T07:40:48.482Z",
+      "first_notified_owner_at": null,
+      "grace_period_expiration": "2023-03-07T07:40:48.482Z",
+      "device": {
+        "id": 23456,
+        "name": "Joe-MacBook",
+        "owned_by": "organization",
+        "privacy": "details_hidden",
+        "platform": "darwin",
+        "enrolled_at": "2022-12-17T18:20:54.110Z",
+        "last_seen_at": "2023-04-06T16:31:42.000Z",
+        "operating_system": "macOS 12.3.2 Monterey Build: 21E258",
+        "issue_count": 1,
+        "resolved_issue_count": 15,
+        "failure_count": 1,
+        "resolved_failure_count": 15,
+        "primary_user_name": "This attribute is DEPRECATED. Primary User is no longer collected.",
+        "hardware_model": "MacBook Pro (14-inch, 2021)",
+        "hardware_vendor": "Apple Inc.",
+        "launcher_version": "0.11.24",
+        "osquery_version": "5.1.0",
+        "serial": "XQ9Q6CMX",
+        "assigned_owner": {
+          "id": 265026,
+          "owner_type": "Person",
+          "name": "Joe John",
+          "email": "joe.john@example.com"
+        },
+        "kolide_mdm": null,
+        "note": null,
+        "note_html": null,
+        "operating_system_details": {
+          "device_id": 87161,
+          "platform": "darwin",
+          "name": "macOS",
+          "codename": "Monterey",
+          "version": "12.3.2",
+          "build": "21E258",
+          "major_version": 12,
+          "minor_version": 3,
+          "patch_version": 1,
+          "ubr": null,
+          "release_id": null
+        },
+        "remote_ip": "149.06.3.65",
+        "location": null,
+        "product_image_url": "https://assets1.kolide.com/assets/inventory/devices/MacBook Pro (14-inch, 2021)-57e6d957a0520ca66e38cd68d5a54fa6c7557dcd.png"
+      }
+    }
+  ],
+  "pagination": {
+    "next": "",
+    "next_cursor": "",
+    "current_cursor": "MjcsMjcp",
+    "count": 1
+  }
+}

--- a/spec/kolide_spec.rb
+++ b/spec/kolide_spec.rb
@@ -12,7 +12,7 @@ describe Kolide do
 
   def stub_api(type)
     content = { status: 200, headers: { "Content-Type" => "application/json" } }
-    url = "#{::Kolide::Api::BASE_URL}#{type == :issues ? "issues/open" : type}?per_page=500"
+    url = "#{::Kolide::Api::BASE_URL}#{type == :issues ? "issues/open" : type}?per_page=100"
     content = content.merge(body: get_kolide_response("#{type}.json"))
     stub_request(:get, url).to_return(content)
   end

--- a/spec/models/check_spec.rb
+++ b/spec/models/check_spec.rb
@@ -6,7 +6,7 @@ require_relative "../spec_helper"
 describe ::Kolide::Check do
   include_context "with kolide spec helper"
 
-  api_url = "#{::Kolide::Api::BASE_URL}checks?per_page=500"
+  api_url = "#{::Kolide::Api::BASE_URL}checks?per_page=100"
 
   before do
     SiteSetting.kolide_enabled = true

--- a/spec/models/device_spec.rb
+++ b/spec/models/device_spec.rb
@@ -6,7 +6,7 @@ require_relative "../spec_helper"
 describe ::Kolide::Device do
   include_context "with kolide spec helper"
 
-  api_url = "#{::Kolide::Api::BASE_URL}devices?per_page=500"
+  api_url = "#{::Kolide::Api::BASE_URL}devices?per_page=100"
 
   before do
     content = { status: 200, headers: { "Content-Type" => "application/json" } }


### PR DESCRIPTION
Kolide's API response is limited to 100 items for GET methods. So we must perform multiple API calls to get all the items.