### PR TITLE
DEV: check old IPs with Kolide to determine onboarded devices.

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-kolide.js
+++ b/assets/javascripts/discourse/initializers/extend-for-kolide.js
@@ -2,6 +2,7 @@ import { withPluginApi } from "discourse/lib/plugin-api";
 import I18n from "I18n";
 import { ajax } from "discourse/lib/ajax";
 import { popupAjaxError } from "discourse/lib/ajax-error";
+import cookie from "discourse/lib/cookie";
 
 function initializeWithApi(api) {
   const currentUser = api.getCurrentUser();
@@ -49,12 +50,11 @@ function initializeWithApi(api) {
     return false;
   }
 
-  if (currentUser) {
-    const site = api.container.lookup("site:main");
+  if (currentUser && !cookie("kolide_onboarded")) {
     const siteSettings = api.container.lookup("site-settings:main");
     const onboarding_topic_id = siteSettings.kolide_onboarding_topic_id;
 
-    if (site.non_onboarded_device && onboarding_topic_id > 0) {
+    if (onboarding_topic_id > 0) {
       api.addGlobalNotice(
         I18n.t("discourse_kolide.non_onboarded_device.notice", {
           link: `/t/${onboarding_topic_id}`,

--- a/lib/application_controller_extension.rb
+++ b/lib/application_controller_extension.rb
@@ -2,9 +2,7 @@
 
 module Kolide::ApplicationControllerExtension
   def self.prepended(base)
-    base.class_eval do
-      base.after_action :ensure_device_onboarded
-    end
+    base.class_eval { base.after_action :ensure_device_onboarded }
 
     protected
 

--- a/lib/application_controller_extension.rb
+++ b/lib/application_controller_extension.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Kolide::ApplicationControllerExtension
+  def self.prepended(base)
+    base.class_eval do
+      base.after_action :ensure_device_onboarded
+    end
+
+    protected
+
+    def ensure_device_onboarded
+      return unless SiteSetting.kolide_enabled?
+      return if current_user.blank? || cookies[:kolide_onboarded].present?
+      return if (request.format && request.format.json?) || request.xhr?
+      return if MobileDetection.mobile_device?(request.user_agent)
+
+      user_auth_token = current_user.user_auth_tokens.find_by(auth_token: guardian.auth_token)
+      return if user_auth_token.blank?
+
+      ips = [request.ip, user_auth_token.client_ip]
+      ips +=
+        current_user
+          .user_auth_token_logs
+          .where(user_auth_token_id: user_auth_token.id)
+          .where("created_at > ?", 20.days.ago)
+          .distinct
+          .pluck(:client_ip)
+
+      if current_user.kolide_devices.exists?(ip_address: ips.uniq)
+        cookies[:kolide_onboarded] = { value: true, expires: 1.month.from_now }
+      end
+    end
+  end
+end

--- a/lib/user_extension.rb
+++ b/lib/user_extension.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Kolide::UserExtension
+  def self.prepended(base)
+    base.has_many :kolide_devices, class_name: "::Kolide::Device"
+
+    base.class_eval do
+      def self.find_by_kolide_json(data)
+        return if data.blank?
+
+        custom_field =
+          UserCustomField.find_or_initialize_by(name: "kolide_person_id", value: data["id"])
+        return custom_field.user unless custom_field.new_record?
+
+        email = data["email"]
+        user = User.find_by_email(email)
+
+        if user.blank?
+          Rails.logger.warn("Unable find the Discourse user for email address '#{email}'")
+          return
+        end
+
+        custom_field.user_id = user.id
+        custom_field.save!
+
+        user
+      end
+    end
+  end
+end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -11,13 +11,13 @@ RSpec.describe ApplicationController do
     end
 
     it "should not create cookie if device not found" do
-      get "/", headers: { "REMOTE_ADDR" => "1.2.3.4"}
+      get "/", headers: { "REMOTE_ADDR" => "1.2.3.4" }
       expect(response.cookies["kolide_onboarded"]).to be_nil
     end
 
     it "should create cookie if device exists" do
       device.update(ip_address: "1.2.3.4")
-      get "/", headers: { "REMOTE_ADDR" => "1.2.3.4"}
+      get "/", headers: { "REMOTE_ADDR" => "1.2.3.4" }
       expect(response.cookies["kolide_onboarded"]).to eq(true.to_s)
     end
   end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+RSpec.describe ApplicationController do
+  fab!(:user) { Fabricate(:user) }
+  fab!(:device) { Fabricate(:kolide_device, user: user, ip_address: "10.7.8.9") }
+
+  describe "#ensure_device_onboarded" do
+    before do
+      SiteSetting.kolide_enabled = true
+      sign_in(user)
+    end
+
+    it "should not create cookie if device not found" do
+      get "/", headers: { "REMOTE_ADDR" => "1.2.3.4"}
+      expect(response.cookies["kolide_onboarded"]).to be_nil
+    end
+
+    it "should create cookie if device exists" do
+      device.update(ip_address: "1.2.3.4")
+      get "/", headers: { "REMOTE_ADDR" => "1.2.3.4"}
+      expect(response.cookies["kolide_onboarded"]).to eq(true.to_s)
+    end
+  end
+end


### PR DESCRIPTION
Previously, we only checked the current IP address of the user to determine whether a device is onboarded or not. It creates problem when the IP address is not updated either in Kolide system or in Discourse. So, now we're including the old IP addresses from the `UserAuthTokenLog` table. Also, we're now creating a cookie to prevent repeated checking.