### PR TITLE
UX: hide non-onboarded device notice on mobile view.

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-kolide.js
+++ b/assets/javascripts/discourse/initializers/extend-for-kolide.js
@@ -51,10 +51,11 @@ function initializeWithApi(api) {
   }
 
   if (currentUser && !cookie("kolide_onboarded")) {
+    const site = api.container.lookup("site:main");
     const siteSettings = api.container.lookup("site-settings:main");
     const onboarding_topic_id = siteSettings.kolide_onboarding_topic_id;
 
-    if (onboarding_topic_id > 0) {
+    if (onboarding_topic_id > 0 && !site.mobileView) {
       api.addGlobalNotice(
         I18n.t("discourse_kolide.non_onboarded_device.notice", {
           link: `/t/${onboarding_topic_id}`,

--- a/test/javascripts/acceptance/discourse-kolide-test.js
+++ b/test/javascripts/acceptance/discourse-kolide-test.js
@@ -1,0 +1,30 @@
+import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
+import { test } from "qunit";
+import { visit } from "@ember/test-helpers";
+
+acceptance("Discourse Kolide Plugin", function (needs) {
+  needs.user();
+  needs.settings({ kolide_onboarding_topic_id: 1 });
+
+  test("displays a notice to non-onboarded devices", async function (assert) {
+    await visit("/");
+    assert.ok(
+      exists(".non-onboarded-device"),
+      "notice is displayed to non-onboarded devices"
+    );
+  });
+});
+
+acceptance("Discourse Kolide Plugin - Mobile", function (needs) {
+  needs.user();
+  needs.mobileView();
+  needs.settings({ kolide_onboarding_topic_id: 1 });
+
+  test("hides the notice on mobile", async function (assert) {
+    await visit("/");
+    assert.notOk(
+      exists(".non-onboarded-device"),
+      "notice is not displayed on mobile"
+    );
+  });
+});

--- a/test/javascripts/acceptance/discourse-kolide-test.js
+++ b/test/javascripts/acceptance/discourse-kolide-test.js
@@ -2,20 +2,7 @@ import { acceptance, exists } from "discourse/tests/helpers/qunit-helpers";
 import { test } from "qunit";
 import { visit } from "@ember/test-helpers";
 
-acceptance("Discourse Kolide Plugin", function (needs) {
-  needs.user();
-  needs.settings({ kolide_onboarding_topic_id: 1 });
-
-  test("displays a notice to non-onboarded devices", async function (assert) {
-    await visit("/");
-    assert.ok(
-      exists(".non-onboarded-device"),
-      "notice is displayed to non-onboarded devices"
-    );
-  });
-});
-
-acceptance("Discourse Kolide Plugin - Mobile", function (needs) {
+acceptance("Discourse Kolide Plugin - Mobile", async function (needs) {
   needs.user();
   needs.mobileView();
   needs.settings({ kolide_onboarding_topic_id: 1 });


### PR DESCRIPTION
We don’t require installing kolide on mobile devices.