### PR TITLE
DEV: Replace deprecated queue_jobs site setting in tests

### DIFF
--- a/spec/requests/webhooks_controller_spec.rb
+++ b/spec/requests/webhooks_controller_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe ::Kolide::WebhooksController do
 
   let(:secret) { SiteSetting.kolide_webhook_secret = "WEBHOOK SECRET" }
 
-  before { SiteSetting.queue_jobs = false }
+  before { Jobs.run_immediately! }
 
   def post_request(body)
     post "/kolide/webhooks",


### PR DESCRIPTION
### What is this change?

The `#queue_jobs=` method on site settings has been [deprecated](https://github.com/discourse/discourse/commit/1b65469b64e9e569fed67ae11f1dd9ee37702f5c) and replaced by `Jobs.run_later!` and `Jobs.run_immediately!`. This PR replaces usages in this plugin so we can remove the fallback in core.

The fallback used in core for reference:

https://github.com/discourse/discourse/blob/main/app/models/site_setting.rb#L109-L115