### PR TITLE
UX: remove user alert notification if all the issues are resolved.

### DIFF
--- a/lib/user_alert.rb
+++ b/lib/user_alert.rb
@@ -32,9 +32,8 @@ module ::Kolide
 
       update_post_body
 
-      issues_to_remind = open_issues
-        .joins(:check)
-        .where(
+      issues_to_remind =
+        open_issues.joins(:check).where(
           "(#{Time.now.to_i} - EXTRACT(EPOCH FROM kolide_issues.reported_at))/3600 > kolide_checks.delay",
         )
       if issues_to_remind.blank?


### PR DESCRIPTION
Previously, the notification which sent to the users for the open issues is keep alerting them even after those issues are resolved.