### PR TITLE
DEV: display the notice even if corresponding Kolide user ID is not available.

### DIFF
--- a/assets/javascripts/discourse/initializers/extend-for-kolide.js
+++ b/assets/javascripts/discourse/initializers/extend-for-kolide.js
@@ -71,7 +71,7 @@ function initializeWithApi(api) {
           {
             dismissable: true,
             persistentDismiss: true,
-            dismissDuration: moment.duration(1, "week"),
+            dismissDuration: moment.duration(1, "day"),
           }
         );
       }

--- a/lib/application_controller_extension.rb
+++ b/lib/application_controller_extension.rb
@@ -6,7 +6,7 @@ module Kolide::ApplicationControllerExtension
 
     def ensure_device_onboarded
       return unless SiteSetting.kolide_enabled?
-      return if current_user.blank? || current_user.kolide_id.blank?
+      return if current_user.blank?
       return if (request.format && request.format.json?) || request.xhr? || !request.get?
       return if MobileDetection.mobile_device?(request.user_agent)
 


### PR DESCRIPTION
Also this change will decrease the dismiss duration for onboarding notice.