### PR TITLE
DEV: delete `kolide_non_onboarded` cookie if onboarding not required.

### DIFF
--- a/lib/application_controller_extension.rb
+++ b/lib/application_controller_extension.rb
@@ -10,7 +10,7 @@ module Kolide::ApplicationControllerExtension
         return
       end
 
-      return if (request.format && request.format.json?) || request.xhr? || !request.get?
+      return if request.format&.json? || request.xhr? || !request.get?
 
       user_auth_token = current_user.user_auth_tokens.find_by(auth_token: guardian.auth_token)
       return if user_auth_token.blank?

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -18,6 +18,16 @@ RSpec.describe ApplicationController do
       expect(response.cookies["kolide_non_onboarded"]).to eq(Time.now.to_i.to_s)
     end
 
+    it "deletes cookie if onboarding is not required" do
+      cookies[:kolide_non_onboarded] = Time.now.to_i
+      get "/",
+          headers: {
+            "HTTP_USER_AGENT" =>
+              "Mozilla/5.0 (X11; CrOS x86_64 11895.95.0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.125 Safari/537.36",
+          }
+      expect(response.cookies["kolide_non_onboarded"]).to be_nil
+    end
+
     it "should create cookie if device exists" do
       cookies[:kolide_device_id] = device.id
       get "/"


### PR DESCRIPTION
Previously, once the `kolide_non_onboarded` cookie is created it won't be removed for a year or until onboarding that device.