### PR TITLE
FEATURE: display onboarding notice only to group members in setting.

### DIFF
--- a/config/locales/server.en.yml
+++ b/config/locales/server.en.yml
@@ -5,6 +5,7 @@ en:
     kolide_webhook_secret: "The string to verify incoming Kolide webhooks"
     kolide_verbose_log: "Enable verbose logging for Kolide plugin"
     kolide_onboarding_topic_id: "Topic with Kolide onboarding instructions for users"
+    kolide_onboarding_group_name: "The onboarding notice will display only for users in this group. Leave blank to display for all users."
     kolide_admin_group_name: "The Kolide admins group name where user device problems will be reported"
     kolide_helpers_group_name: "The group name of Kolide helpers who will help users to resolve their open issues"
   kolide:

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -13,6 +13,9 @@ plugins:
   kolide_onboarding_topic_id:
     default: 0
     client: true
+  kolide_onboarding_group_name:
+    default: ""
+    type: group
   kolide_admin_group_name:
     default: ""
     type: group

--- a/lib/application_controller_extension.rb
+++ b/lib/application_controller_extension.rb
@@ -36,7 +36,8 @@ module Kolide::ApplicationControllerExtension
       return false if MobileDetection.mobile_device?(user_agent)
       return false if %i[ipad chromebook].include?(BrowserDetection.device(user_agent))
 
-      true
+      onboarding_group = SiteSetting.kolide_onboarding_group_name
+      onboarding_group.blank? || current_user.groups.exists?(name: onboarding_group)
     end
   end
 end

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -33,5 +33,17 @@ RSpec.describe ApplicationController do
       get "/"
       expect(response.cookies["kolide_non_onboarded"]).to be_nil
     end
+
+    it "should create cookie only if member of onboarding group" do
+      group = Fabricate(:group, name: "onboarding")
+      SiteSetting.kolide_onboarding_group_name = "onboarding"
+
+      get "/"
+      expect(response.cookies["kolide_non_onboarded"]).to be_nil
+
+      group.add(user)
+      get "/"
+      expect(response.cookies["kolide_non_onboarded"]).to eq(Time.now.to_i.to_s)
+    end
   end
 end


### PR DESCRIPTION
If you specify a value for  site setting then the onboarding notice will be displayed only for the members of that group. Else it will displayed to everyone when the setting is empty.