### PR TITLE
FEATURE: new checkbox to mark a device as mobile in onboarding

### DIFF
--- a/app/controllers/devices_controller.rb
+++ b/app/controllers/devices_controller.rb
@@ -10,11 +10,20 @@ module ::Kolide
     end
 
     def current
-      params.require(:device_id)
-      device = Device.find_by(id: params[:device_id])
-      return render json: failed_json, status: 422 if device.blank?
+      device_id = params[:device_id]
+      is_mobile = params[:is_mobile]
 
-      cookies.permanent[:kolide_device_id] = device.id
+      raise Discourse::NotFound if device_id.blank? && is_mobile.blank?
+
+      if is_mobile.present?
+        cookies.permanent[:kolide_device_id] = "mobile"
+      else
+        device = Device.find_by(id: device_id)
+        return render json: failed_json, status: 422 if device.blank?
+
+        cookies.permanent[:kolide_device_id] = device.id
+      end
+
       cookies.delete(:kolide_non_onboarded)
       render json: success_json, status: 200
     end

--- a/assets/javascripts/discourse/controllers/preferences/kolide.js
+++ b/assets/javascripts/discourse/controllers/preferences/kolide.js
@@ -11,6 +11,7 @@ export default class extends Controller {
   @service siteSettings;
 
   @tracked deviceId = null;
+  @tracked mobileDevice = false;
   @tracked loading = false;
   @tracked refreshing = false;
 
@@ -21,7 +22,7 @@ export default class extends Controller {
 
   @action
   async setKolideDevice() {
-    if (!this.deviceId) {
+    if (!this.mobileDevice && !this.deviceId) {
       this.dialog.alert({
         message: I18n.t("discourse_kolide.onboarding.device_empty"),
       });
@@ -37,7 +38,11 @@ export default class extends Controller {
       data: new FormData(),
     };
 
-    options.data.append("device_id", this.deviceId);
+    if (this.mobileDevice) {
+      options.data.append("is_mobile", true);
+    } else {
+      options.data.append("device_id", this.deviceId);
+    }
 
     ajax("/kolide/devices/current", options)
       .then(() => {

--- a/assets/javascripts/discourse/routes/preferences-kolide.js
+++ b/assets/javascripts/discourse/routes/preferences-kolide.js
@@ -13,7 +13,11 @@ export default class PreferencesKolideRoute extends RestrictedUserRoute {
     const deviceId = cookie("kolide_device_id");
 
     if (deviceId) {
-      controller.set("deviceId", parseInt(deviceId, 10));
+      if (deviceId === "mobile") {
+        controller.set("mobileDevice", true);
+      } else {
+        controller.set("deviceId", parseInt(deviceId, 10));
+      }
     }
   }
 }

--- a/assets/javascripts/discourse/templates/preferences/kolide.hbs
+++ b/assets/javascripts/discourse/templates/preferences/kolide.hbs
@@ -35,10 +35,7 @@
       <div class="controls">
         <div class="inline-form">
           <label>
-            <Input
-              @type="checkbox"
-              @checked={{this.mobileDevice}}
-            />
+            <Input @type="checkbox" @checked={{this.mobileDevice}} />
             {{i18n "discourse_kolide.onboarding.is_mobile_device"}}
           </label>
         </div>

--- a/assets/javascripts/discourse/templates/preferences/kolide.hbs
+++ b/assets/javascripts/discourse/templates/preferences/kolide.hbs
@@ -36,7 +36,7 @@
         <div class="inline-form">
           <label>
             <Input @type="checkbox" @checked={{this.mobileDevice}} />
-            {{i18n "discourse_kolide.onboarding.is_mobile_device"}}
+            {{i18n "discourse_kolide.onboarding.kolide_not_available"}}
           </label>
         </div>
       </div>

--- a/assets/javascripts/discourse/templates/preferences/kolide.hbs
+++ b/assets/javascripts/discourse/templates/preferences/kolide.hbs
@@ -31,6 +31,18 @@
           }}
         </div>
       </div>
+
+      <div class="controls">
+        <div class="inline-form">
+          <label>
+            <Input
+              @type="checkbox"
+              @checked={{this.mobileDevice}}
+            />
+            {{i18n "discourse_kolide.onboarding.is_mobile_device"}}
+          </label>
+        </div>
+      </div>
     </div>
 
     <div class="control-group">

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -15,6 +15,7 @@ en:
           Please select the current device's name from the list of onboarded devices on Kolide.
           If you didn't onboard this device yet then follow <a href='%{topicLink}'>this guide</a>.
           If you don't see an already onboarded device's name then click the %{refreshIcon} button.
+        is_mobile_device: This is a mobile device
         save_device: Save device
         refresh_devices: Refresh devices
         device_saved: Selected device name is successfully saved as current device.

--- a/config/locales/client.en.yml
+++ b/config/locales/client.en.yml
@@ -15,7 +15,7 @@ en:
           Please select the current device's name from the list of onboarded devices on Kolide.
           If you didn't onboard this device yet then follow <a href='%{topicLink}'>this guide</a>.
           If you don't see an already onboarded device's name then click the %{refreshIcon} button.
-        is_mobile_device: This is a mobile device
+        kolide_not_available: Kolide is not available for this device
         save_device: Save device
         refresh_devices: Refresh devices
         device_saved: Selected device name is successfully saved as current device.

--- a/lib/application_controller_extension.rb
+++ b/lib/application_controller_extension.rb
@@ -17,7 +17,8 @@ module Kolide::ApplicationControllerExtension
 
       device_id = cookies[:kolide_device_id]
       if device_id.present?
-        if ::Kolide::Device.where(id: device_id.to_i, user_id: [nil, current_user.id]).exists?
+        if device_id == "mobile" ||
+             ::Kolide::Device.exists?(id: device_id.to_i, user_id: [nil, current_user.id])
           cookies.delete(:kolide_non_onboarded)
           return
         else

--- a/spec/requests/application_controller_spec.rb
+++ b/spec/requests/application_controller_spec.rb
@@ -28,8 +28,14 @@ RSpec.describe ApplicationController do
       expect(response.cookies["kolide_non_onboarded"]).to be_nil
     end
 
-    it "should create cookie if device exists" do
+    it "should not create cookie if device exists" do
       cookies[:kolide_device_id] = device.id
+      get "/"
+      expect(response.cookies["kolide_non_onboarded"]).to be_nil
+    end
+
+    it "should not create cookie if device is mobile" do
+      cookies[:kolide_device_id] = "mobile"
       get "/"
       expect(response.cookies["kolide_non_onboarded"]).to be_nil
     end

--- a/spec/requests/devices_controller_spec.rb
+++ b/spec/requests/devices_controller_spec.rb
@@ -39,6 +39,15 @@ RSpec.describe ::Kolide::DevicesController do
       expect(response.status).to eq(200)
       expect(response.cookies["kolide_device_id"]).to eq(device.id.to_s)
     end
+
+    it "sets the current device id in a cookie for mobile" do
+      sign_in(user)
+
+      post "/kolide/devices/current.json", params: { is_mobile: true }
+
+      expect(response.status).to eq(200)
+      expect(response.cookies["kolide_device_id"]).to eq("mobile")
+    end
   end
 
   describe "refresh" do


### PR DESCRIPTION
Sometimes we're unable to detect the mobile devices from their user agent to skip the Kolide onboarding. For example, in the latest iPadOS 13 Beta, Apple claimed desktop-class browsing in Safari. It seems Safari mimics macOS behavior and user agent. This commit gives the ability to users to choose whether the current device is mobile or not.

<img width="422" alt="Screenshot 2024-01-28 at 1 50 04 PM" src="https://github.com/discourse/discourse-kolide/assets/9372109/2e9edc9e-4925-4eb5-a857-44992f40fa15">