### PR TITLE
FIX: Display post body when there are only upcoming issues

### DIFF
--- a/lib/user_alert.rb
+++ b/lib/user_alert.rb
@@ -108,7 +108,7 @@ module ::Kolide
     end
 
     def post_body
-      return I18n.t("kolide.alert.no_issues") unless open_issues.exists?
+      return I18n.t("kolide.alert.no_issues") unless open_issues.exists? || upcoming_issues.exists?
 
       open_issues_list = build_list_for(:open)
       upcoming_issues_list = build_list_for(:upcoming)


### PR DESCRIPTION
The previous check only would display the post body for "open issues"
without the delay check. Now that we have the upcoming issues and the
open issues section we need to still show the post body if there are
only "upcoming issues". Otherwise if we only have upcoming issues the
post body won't be displayed.

Follow up to: bb95792988137e3d2add4f5e0a2927bd2283aea0
