### PR TITLE
DEV: updates kolide following v0 deprecation

### DIFF
--- a/lib/api.rb
+++ b/lib/api.rb
@@ -7,19 +7,21 @@ module ::Kolide
   class Api
     attr_reader :client
 
+    BASE_URL = "https://api.kolide.com/"
+    API_VERSION = "2023-05-26"
+
     def initialize
       @client =
         Faraday.new(
           url: Api::BASE_URL,
           headers: {
             "Authorization" => "Bearer #{SiteSetting.kolide_api_key}",
+            "X-Kolide-Api-Version" => API_VERSION,
             "Accept" => "application/json",
             "Content-Type" => "application/json",
           },
         )
     end
-
-    BASE_URL = "https://k2.kolide.com/api/v0/"
 
     def parse(response)
       case response.status

--- a/spec/fixtures/issues.json
+++ b/spec/fixtures/issues.json
@@ -145,7 +145,7 @@
     }
   ],
   "pagination": {
-    "next": "https://k2.kolide.com/api/v0/issues/open?cursor=MjcsMjcp",
+    "next": "https://api.kolide.com/issues/open?cursor=MjcsMjcp",
     "next_cursor": "MjcsMjcp",
     "current_cursor": "",
     "count": 25


### PR DESCRIPTION
We are starting to be rate limited and need to update the API: https://www.kolide.com/docs/developers/v0-api-deprecation

Example logs we have atm:

```
Invalid response received from Kolide API : Kolide::InvalidApiResponse : {"error":"Too many requests. API is deprecated. Please migrate to the current API version.","deprecation_info":"https://www.kolide.com/docs/developers/api"}
```